### PR TITLE
Interface interaction visualization with dashed lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,9 +1654,10 @@ dependencies = [
 
 [[package]]
 name = "proteinview"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "crossterm",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,10 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "proteinview"
-version = "0.2.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
- "base64",
  "clap",
  "crossterm",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proteinview"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2024"
 description = "Terminal protein structure viewer"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@ Terminal molecular structure viewer -- load, rotate, and explore proteins, nucle
 
 ## Features
 
-- **Braille character rendering** -- high-resolution colored Unicode braille (2x4 dots per cell), works everywhere including SSH
-- **HD pixel rendering** -- Sixel/Kitty/iTerm2 graphics protocol support via ratatui-image for pixel-perfect display (`--hd`) with 24-bit depth-tinted shading
+- **3-tier render modes** -- Braille (text, works everywhere), HD (shaded braille with Lambert lighting), FullHD (Sixel/Kitty pixel graphics with PNG compression)
+- **SSH-aware rendering** -- auto-detects SSH connections; `--hd` defaults to fast text-based HD over SSH, FullHD locally. PNG-compressed Kitty protocol (~10-20x smaller than raw RGBA) makes FullHD viable even over SSH
 - **Cartoon ribbon visualization** -- smooth ribbon/tube rendering with depth fog and Lambert shading for helices, beta-sheets, and coils
 - **RNA/DNA structure support** -- backbone, wireframe, and cartoon modes with nucleotide base-type coloring (A=red, U/T=blue, G=green, C=yellow)
 - **Small molecule rendering** -- ligands displayed as ball-and-stick, ions as spheres; water molecules (HOH/WAT) automatically excluded
 - **3 visualization modes** -- Cartoon (ribbon), Backbone (CA trace / C4' trace), Wireframe (all-atom bonds)
-- **5 color schemes** -- secondary structure, chain, element, B-factor, rainbow
+- **7 color schemes** -- secondary structure, chain, element, B-factor, rainbow, pLDDT confidence (AlphaFold)
 - **Interactive rotation, zoom, pan** -- vim-style keybindings with auto-rotation
 - **Protein-protein interface analysis** -- detect and highlight inter-chain contacts with ligand binding pocket detection
+- **Interface interaction visualization** -- toggle dashed lines showing H-bonds, salt bridges, hydrophobic contacts, and other interactions color-coded by type
 - **NMR multi-model PDB handling** -- loads first model only for clean display
 - **PDB and mmCIF format support** -- including secondary structure parsing from both formats
 - **Fetch from RCSB PDB** -- download structures by ID with `--fetch` (optional feature)
@@ -66,8 +67,11 @@ This builds the binary and places it in `~/.cargo/bin/`, which is already on you
 # View a local PDB file
 proteinview examples/1UBQ.pdb
 
-# HD pixel mode (Sixel/Kitty/iTerm2 terminals)
+# HD mode (shaded braille -- fast over SSH)
 proteinview examples/4HHB.pdb --hd
+
+# FullHD pixel mode (Sixel/Kitty/iTerm2 -- PNG compressed)
+proteinview examples/4HHB.pdb --fullhd
 
 # Choose color scheme
 proteinview examples/1UBQ.pdb --color rainbow
@@ -75,29 +79,35 @@ proteinview examples/1UBQ.pdb --color rainbow
 # Choose visualization mode
 proteinview examples/4HHB.pdb --mode wireframe
 
+# Explicit render mode
+proteinview examples/1UBQ.pdb --render halfblock
+proteinview examples/1UBQ.pdb --render fullhd
+
 # Fetch from RCSB PDB (requires --features fetch)
 proteinview --fetch 1UBQ
 ```
 
 ## Keybindings
 
-| Key       | Action                     |
-|-----------|----------------------------|
-| `h` / `l` | Rotate Y-axis              |
-| `j` / `k` | Rotate X-axis              |
-| `u` / `i` | Rotate Z-axis (roll)       |
-| `+` / `-` | Zoom in / out              |
-| `w/a/s/d` | Pan                        |
-| `r`       | Reset view                 |
-| `c`       | Cycle color scheme         |
-| `v`       | Cycle visualization mode   |
-| `f`       | Toggle interface analysis  |
-| `m`       | Toggle braille / HD        |
-| `g`       | Toggle ligand visibility   |
-| `[` / `]` | Previous / next chain      |
-| `Space`   | Toggle auto-rotation       |
-| `?`       | Help overlay               |
-| `q`       | Quit                       |
+| Key       | Action                              |
+|-----------|-------------------------------------|
+| `h` / `l` | Rotate Y-axis                      |
+| `j` / `k` | Rotate X-axis                      |
+| `u` / `i` | Rotate Z-axis (roll)               |
+| `+` / `-` | Zoom in / out                      |
+| `w/a/s/d` | Pan                                |
+| `r`       | Reset view                          |
+| `c`       | Cycle color scheme                  |
+| `v`       | Cycle visualization mode            |
+| `m`       | Toggle Braille / HD                 |
+| `M`       | Toggle HD / FullHD (Sixel/Kitty)    |
+| `f`       | Toggle interface analysis           |
+| `I`       | Toggle interface interactions       |
+| `g`       | Toggle ligand visibility            |
+| `[` / `]` | Previous / next chain              |
+| `Space`   | Toggle auto-rotation                |
+| `?`       | Help overlay                        |
+| `q`       | Quit                                |
 
 ## Visualization Modes
 
@@ -133,15 +143,16 @@ proteinview --fetch 1UBQ
 
 ### Interface Analysis
 
-Press `f` to toggle the protein-protein interface panel, which detects inter-chain contacts, highlights interface residues, and identifies ligand binding pockets with their coordinating residues.
+Press `f` to toggle the protein-protein interface panel, which detects inter-chain contacts, highlights interface residues, and identifies ligand binding pockets with their coordinating residues. Press `I` (Shift+I) to overlay dashed interaction lines color-coded by type: cyan (H-bonds), red (salt bridges), yellow (hydrophobic contacts), gray (other).
 
 ![Interface analysis panel showing chain contacts](assets/interface-cartoon-1zvh.png)
 
 ## Terminal Support
 
-- Works in any terminal with Unicode support (braille mode).
-- For best quality, use a terminal with Sixel or Kitty graphics protocol support (e.g., WezTerm, Kitty, foot, iTerm2) and pass `--hd`.
-- The `--hd` flag auto-detects the best graphics protocol; falls back to colored braille if none available.
+- **Braille** -- works in any terminal with Unicode support, including over SSH and inside tmux/screen.
+- **HD** (`--hd`) -- shaded braille with Lambert lighting and depth fog. Fast everywhere including SSH.
+- **FullHD** (`--fullhd`) -- Sixel/Kitty/iTerm2 pixel graphics. Best quality. Over SSH, uses PNG compression (~10-20x smaller) for responsive performance.
+- `--hd` is SSH-aware: defaults to HD (text) over SSH, FullHD locally. Use `--fullhd` to force pixel graphics regardless of connection.
 
 ## Building
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,6 +92,7 @@ pub struct App {
     pub show_help: bool,
     pub show_ligands: bool,
     pub show_interface: bool,
+    pub show_interactions: bool,
     pub interface_analysis: InterfaceAnalysis,
     pub should_quit: bool,
     /// Whether the B-factor column likely contains pLDDT confidence scores.
@@ -187,6 +188,7 @@ impl App {
             show_help: false,
             show_ligands: true,
             show_interface: false,
+            show_interactions: false,
             interface_analysis,
             should_quit: false,
             has_plddt,
@@ -225,11 +227,18 @@ impl App {
         if self.show_interface {
             self.rebuild_interface_colors();
         } else {
+            self.show_interactions = false;
             self.color_scheme = ColorScheme::new(
                 ColorSchemeType::Structure,
                 self.protein.residue_count(),
             );
             self.mesh_dirty = true;
+        }
+    }
+
+    pub fn toggle_interactions(&mut self) {
+        if self.show_interface {
+            self.show_interactions = !self.show_interactions;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,7 @@ fn main() -> Result<()> {
                 KeyCode::Char(']') => app.next_chain(),
                 KeyCode::Char(' ') => app.camera.auto_rotate = !app.camera.auto_rotate,
                 KeyCode::Char('f') => app.toggle_interface(),
+                KeyCode::Char('I') => app.toggle_interactions(),
                 KeyCode::Char('g') => app.toggle_ligands(),
                 KeyCode::Char('?') => app.show_help = !app.show_help,
                 KeyCode::Esc => { if app.show_help { app.show_help = false; } },
@@ -286,12 +287,15 @@ fn main() -> Result<()> {
 
                 let summary = app.interface_analysis.summary(&app.protein);
                 let chain_names = app.chain_names();
+                let interaction_counts = app.interface_analysis.interaction_counts();
                 ui::interface_panel::render_interface_panel(
                     frame,
                     horiz[0],
                     &summary,
                     app.current_chain,
                     &chain_names,
+                    app.show_interactions,
+                    interaction_counts,
                 );
                 horiz[1]
             } else {

--- a/src/model/interface.rs
+++ b/src/model/interface.rs
@@ -80,8 +80,8 @@ fn dist_sq(ax: f64, ay: f64, az: f64, bx: f64, by: f64, bz: f64) -> f64 {
     dx * dx + dy * dy + dz * dz
 }
 
-/// Returns true if the atom on a positively-charged residue side-chain
-/// carries formal positive charge (ARG NH*/NE, LYS NZ).
+/// Returns true if the atom is part of the positively-charged group
+/// (ARG guanidinium NE/NH1/NH2, LYS ammonium NZ).
 fn is_charged_positive(res_name: &str, atom_name: &str) -> bool {
     match res_name {
         "ARG" => atom_name.starts_with("NH") || atom_name == "NE",
@@ -107,18 +107,30 @@ fn is_hydrophobic_residue(name: &str) -> bool {
 
 /// Classify inter-chain interactions from the given contacts.
 ///
-/// For each Contact the function finds the closest heavy-atom pair between
-/// the two residues and classifies the interaction by distance and chemistry:
-///   - **H-bond**: N/O donor to N/O/S acceptor, distance <= 3.5 A
-///   - **Salt bridge**: charged N to charged O (or vice-versa), distance <= 4.0 A
-///   - **Hydrophobic contact**: C-C on hydrophobic residues, distance <= 4.5 A
-///   - **Other**: anything not matching the above
+/// For each [`Contact`] the function finds the closest heavy-atom pair between
+/// the two residues and classifies the interaction by distance and chemistry.
+/// Classification uses a priority order — the first matching rule wins:
+///
+///   1. **Salt bridge** (distance <= 4.0 A): a positively-charged sidechain
+///      atom (ARG NE/NH1/NH2, LYS NZ) paired with a negatively-charged
+///      sidechain atom (ASP OD*, GLU OE*), checked symmetrically.
+///   2. **H-bond** (distance <= 3.5 A): both atoms drawn from {N, O, S},
+///      with at least one being N or O.
+///   3. **Hydrophobic contact** (distance <= 4.5 A): C–C pair where both
+///      residues are hydrophobic (ALA, VAL, LEU, ILE, PHE, TRP, MET, PRO).
+///   4. **Other**: anything not matching the above.
+///
+/// **Limitation:** classification is based on the single closest heavy-atom
+/// pair per contact, which may miss secondary interactions (e.g. a salt bridge
+/// at 3.8 A when a closer C–C pair exists at 3.5 A).
 fn classify_interactions(protein: &Protein, contacts: &[Contact]) -> Vec<Interaction> {
     let mut interactions = Vec::with_capacity(contacts.len());
 
     for contact in contacts {
-        let res_a = &protein.chains[contact.chain_a].residues[contact.residue_a];
-        let res_b = &protein.chains[contact.chain_b].residues[contact.residue_b];
+        let Some(chain_a) = protein.chains.get(contact.chain_a) else { continue };
+        let Some(chain_b) = protein.chains.get(contact.chain_b) else { continue };
+        let Some(res_a) = chain_a.residues.get(contact.residue_a) else { continue };
+        let Some(res_b) = chain_b.residues.get(contact.residue_b) else { continue };
 
         // Find the closest heavy-atom pair.
         let mut best_dist_sq = f64::MAX;
@@ -126,11 +138,11 @@ fn classify_interactions(protein: &Protein, contacts: &[Contact]) -> Vec<Interac
         let mut best_b: Option<&crate::model::protein::Atom> = None;
 
         for atom_a in &res_a.atoms {
-            if atom_a.element == "H" {
+            if atom_a.element.trim() == "H" {
                 continue;
             }
             for atom_b in &res_b.atoms {
-                if atom_b.element == "H" {
+                if atom_b.element.trim() == "H" {
                     continue;
                 }
                 let d_sq = dist_sq(atom_a.x, atom_a.y, atom_a.z, atom_b.x, atom_b.y, atom_b.z);
@@ -224,11 +236,11 @@ pub fn analyze_interface(protein: &Protein, cutoff: f64) -> InterfaceAnalysis {
 
                     // Compare all heavy-atom pairs between the two residues.
                     for atom_a in &res_i.atoms {
-                        if atom_a.element == "H" {
+                        if atom_a.element.trim() == "H" {
                             continue;
                         }
                         for atom_b in &res_j.atoms {
-                            if atom_b.element == "H" {
+                            if atom_b.element.trim() == "H" {
                                 continue;
                             }
                             let d_sq =
@@ -756,5 +768,270 @@ mod tests {
         let bp = analyze_binding_pockets(&protein, 4.5);
         assert!(!bp.contacts.is_empty());
         assert!(bp.pockets[0].contains(&(0, 0))); // chain A res 0 at origin, dist 1.0
+    }
+
+    // ---------------------------------------------------------------
+    // Helper for classify_interactions tests
+    // ---------------------------------------------------------------
+
+    /// Build an `Atom` with the given name, element, and coordinates.
+    fn make_atom(name: &str, element: &str, x: f64, y: f64, z: f64) -> Atom {
+        Atom {
+            name: name.to_string(),
+            element: element.to_string(),
+            x,
+            y,
+            z,
+            b_factor: 0.0,
+            is_backbone: name == "CA" || name == "C" || name == "N" || name == "O",
+            is_hetero: false,
+        }
+    }
+
+    /// Build a two-chain protein where each chain has a single residue with
+    /// the given atoms. Returns the protein and a pre-built contact vector
+    /// pointing at residue 0 on each chain, ready for `classify_interactions`.
+    fn interaction_protein(
+        res_a_name: &str,
+        atoms_a: Vec<Atom>,
+        res_b_name: &str,
+        atoms_b: Vec<Atom>,
+    ) -> (Protein, Vec<Contact>) {
+        let protein = Protein {
+            name: "interaction_test".to_string(),
+            chains: vec![
+                Chain {
+                    id: "A".to_string(),
+                    residues: vec![Residue {
+                        name: res_a_name.to_string(),
+                        seq_num: 1,
+                        atoms: atoms_a,
+                        secondary_structure: SecondaryStructure::Coil,
+                    }],
+                    molecule_type: MoleculeType::Protein,
+                },
+                Chain {
+                    id: "B".to_string(),
+                    residues: vec![Residue {
+                        name: res_b_name.to_string(),
+                        seq_num: 1,
+                        atoms: atoms_b,
+                        secondary_structure: SecondaryStructure::Coil,
+                    }],
+                    molecule_type: MoleculeType::Protein,
+                },
+            ],
+            ligands: Vec::new(),
+        };
+        let contacts = vec![Contact {
+            chain_a: 0,
+            residue_a: 0,
+            chain_b: 1,
+            residue_b: 0,
+            min_distance: 0.0, // placeholder; classify_interactions recomputes
+        }];
+        (protein, contacts)
+    }
+
+    // ---------------------------------------------------------------
+    // classify_interactions tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_classify_salt_bridge() {
+        // ARG NH2 at origin, ASP OD1 at 3.5 A along x => distance 3.5 <= 4.0
+        let (protein, contacts) = interaction_protein(
+            "ARG",
+            vec![make_atom("NH2", "N", 0.0, 0.0, 0.0)],
+            "ASP",
+            vec![make_atom("OD1", "O", 3.5, 0.0, 0.0)],
+        );
+        let interactions = classify_interactions(&protein, &contacts);
+        assert_eq!(interactions.len(), 1);
+        assert_eq!(interactions[0].interaction_type, InteractionType::SaltBridge);
+        assert!((interactions[0].distance - 3.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_classify_hydrogen_bond() {
+        // SER N at origin, THR O at 3.0 A => H-bond (N/O donor-acceptor, <= 3.5)
+        let (protein, contacts) = interaction_protein(
+            "SER",
+            vec![make_atom("N", "N", 0.0, 0.0, 0.0)],
+            "THR",
+            vec![make_atom("O", "O", 3.0, 0.0, 0.0)],
+        );
+        let interactions = classify_interactions(&protein, &contacts);
+        assert_eq!(interactions.len(), 1);
+        assert_eq!(
+            interactions[0].interaction_type,
+            InteractionType::HydrogenBond
+        );
+    }
+
+    #[test]
+    fn test_classify_hydrophobic_contact() {
+        // ALA C at origin, VAL C at 4.0 A => hydrophobic (C-C on hydrophobic residues, <= 4.5)
+        let (protein, contacts) = interaction_protein(
+            "ALA",
+            vec![make_atom("CB", "C", 0.0, 0.0, 0.0)],
+            "VAL",
+            vec![make_atom("CB", "C", 4.0, 0.0, 0.0)],
+        );
+        let interactions = classify_interactions(&protein, &contacts);
+        assert_eq!(interactions.len(), 1);
+        assert_eq!(
+            interactions[0].interaction_type,
+            InteractionType::HydrophobicContact
+        );
+    }
+
+    #[test]
+    fn test_classify_other_fallback() {
+        // ASP C at origin, SER C at 3.0 A => C-C but neither residue is hydrophobic
+        // and elements are C (not N/O), so falls through to Other.
+        let (protein, contacts) = interaction_protein(
+            "ASP",
+            vec![make_atom("CB", "C", 0.0, 0.0, 0.0)],
+            "SER",
+            vec![make_atom("CB", "C", 3.0, 0.0, 0.0)],
+        );
+        let interactions = classify_interactions(&protein, &contacts);
+        assert_eq!(interactions.len(), 1);
+        assert_eq!(interactions[0].interaction_type, InteractionType::Other);
+    }
+
+    #[test]
+    fn test_classify_salt_bridge_priority_over_hbond() {
+        // ARG NH2 (N) and ASP OD1 (O) at 3.0 A satisfies BOTH salt bridge (<= 4.0)
+        // AND H-bond (<= 3.5 with N/O). Salt bridge should win because it is
+        // checked first in the classification cascade.
+        let (protein, contacts) = interaction_protein(
+            "ARG",
+            vec![make_atom("NH2", "N", 0.0, 0.0, 0.0)],
+            "ASP",
+            vec![make_atom("OD1", "O", 3.0, 0.0, 0.0)],
+        );
+        let interactions = classify_interactions(&protein, &contacts);
+        assert_eq!(interactions.len(), 1);
+        assert_eq!(interactions[0].interaction_type, InteractionType::SaltBridge);
+    }
+
+    // ---------------------------------------------------------------
+    // Helper predicate tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_is_charged_positive() {
+        assert!(is_charged_positive("ARG", "NH1"));
+        assert!(is_charged_positive("ARG", "NH2"));
+        assert!(is_charged_positive("ARG", "NE"));
+        assert!(is_charged_positive("LYS", "NZ"));
+        // Non-charged atoms on charged residues should be false.
+        assert!(!is_charged_positive("LYS", "CA"));
+        assert!(!is_charged_positive("ARG", "CA"));
+        // Unrelated residues.
+        assert!(!is_charged_positive("ALA", "N"));
+        assert!(!is_charged_positive("SER", "OG"));
+    }
+
+    #[test]
+    fn test_is_charged_negative() {
+        assert!(is_charged_negative("ASP", "OD1"));
+        assert!(is_charged_negative("ASP", "OD2"));
+        assert!(is_charged_negative("GLU", "OE1"));
+        assert!(is_charged_negative("GLU", "OE2"));
+        // Non-charged atoms on charged residues.
+        assert!(!is_charged_negative("ASP", "CA"));
+        assert!(!is_charged_negative("GLU", "CA"));
+        // Unrelated residues.
+        assert!(!is_charged_negative("ALA", "O"));
+    }
+
+    #[test]
+    fn test_is_hydrophobic_residue() {
+        // All hydrophobic residues.
+        for name in &["ALA", "VAL", "LEU", "ILE", "PHE", "TRP", "MET", "PRO"] {
+            assert!(
+                is_hydrophobic_residue(name),
+                "{} should be hydrophobic",
+                name
+            );
+        }
+        // Polar / charged residues.
+        for name in &[
+            "ASP", "GLU", "LYS", "ARG", "SER", "THR", "ASN", "GLN", "HIS", "GLY", "CYS", "TYR",
+        ] {
+            assert!(
+                !is_hydrophobic_residue(name),
+                "{} should NOT be hydrophobic",
+                name
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // interaction_counts() test
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_interaction_counts() {
+        let analysis = InterfaceAnalysis {
+            contacts: Vec::new(),
+            interface_residues: HashSet::new(),
+            chain_interface_counts: Vec::new(),
+            total_interface_residues: 0,
+            binding_pockets: None,
+            interactions: vec![
+                Interaction {
+                    interaction_type: InteractionType::HydrogenBond,
+                    atom_a: [0.0; 3],
+                    atom_b: [1.0, 0.0, 0.0],
+                    distance: 1.0,
+                },
+                Interaction {
+                    interaction_type: InteractionType::HydrogenBond,
+                    atom_a: [0.0; 3],
+                    atom_b: [2.0, 0.0, 0.0],
+                    distance: 2.0,
+                },
+                Interaction {
+                    interaction_type: InteractionType::SaltBridge,
+                    atom_a: [0.0; 3],
+                    atom_b: [3.0, 0.0, 0.0],
+                    distance: 3.0,
+                },
+                Interaction {
+                    interaction_type: InteractionType::HydrophobicContact,
+                    atom_a: [0.0; 3],
+                    atom_b: [4.0, 0.0, 0.0],
+                    distance: 4.0,
+                },
+                Interaction {
+                    interaction_type: InteractionType::HydrophobicContact,
+                    atom_a: [0.0; 3],
+                    atom_b: [4.0, 0.0, 0.0],
+                    distance: 4.0,
+                },
+                Interaction {
+                    interaction_type: InteractionType::HydrophobicContact,
+                    atom_a: [0.0; 3],
+                    atom_b: [4.0, 0.0, 0.0],
+                    distance: 4.0,
+                },
+                Interaction {
+                    interaction_type: InteractionType::Other,
+                    atom_a: [0.0; 3],
+                    atom_b: [5.0, 0.0, 0.0],
+                    distance: 5.0,
+                },
+            ],
+        };
+
+        let (hbonds, salt_bridges, hydrophobic, other) = analysis.interaction_counts();
+        assert_eq!(hbonds, 2);
+        assert_eq!(salt_bridges, 1);
+        assert_eq!(hydrophobic, 3);
+        assert_eq!(other, 1);
     }
 }

--- a/src/model/interface.rs
+++ b/src/model/interface.rs
@@ -17,6 +17,9 @@ pub struct Interaction {
     pub interaction_type: InteractionType,
     pub atom_a: [f64; 3],
     pub atom_b: [f64; 3],
+    /// Distance in angstroms between the two atoms. Stored for future
+    /// display in tooltips or filtering by distance threshold.
+    #[allow(dead_code)]
     pub distance: f64,
 }
 

--- a/src/model/interface.rs
+++ b/src/model/interface.rs
@@ -2,6 +2,25 @@ use std::collections::HashSet;
 
 use crate::model::protein::Protein;
 
+/// Classification of inter-residue interactions at a chain interface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InteractionType {
+    HydrogenBond,
+    SaltBridge,
+    HydrophobicContact,
+    Other,
+}
+
+/// A classified interaction between two atoms across a chain interface.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Interaction {
+    pub interaction_type: InteractionType,
+    pub atom_a: [f64; 3],
+    pub atom_b: [f64; 3],
+    pub distance: f64,
+}
+
 /// A contact between two residues on different chains.
 #[derive(Debug, Clone)]
 pub struct Contact {
@@ -46,6 +65,8 @@ pub struct InterfaceAnalysis {
     /// Total number of unique interface residues across all chains.
     pub total_interface_residues: usize,
     pub binding_pockets: Option<BindingPocketAnalysis>,
+    /// Classified atom-atom interactions across chain interfaces.
+    pub interactions: Vec<Interaction>,
 }
 
 /// Squared Euclidean distance between two atoms.
@@ -55,6 +76,123 @@ fn dist_sq(ax: f64, ay: f64, az: f64, bx: f64, by: f64, bz: f64) -> f64 {
     let dy = ay - by;
     let dz = az - bz;
     dx * dx + dy * dy + dz * dz
+}
+
+/// Returns true if the atom on a positively-charged residue side-chain
+/// carries formal positive charge (ARG NH*/NE, LYS NZ).
+fn is_charged_positive(res_name: &str, atom_name: &str) -> bool {
+    match res_name {
+        "ARG" => atom_name.starts_with("NH") || atom_name == "NE",
+        "LYS" => atom_name == "NZ",
+        _ => false,
+    }
+}
+
+/// Returns true if the atom on a negatively-charged residue side-chain
+/// carries formal negative charge (ASP OD*, GLU OE*).
+fn is_charged_negative(res_name: &str, atom_name: &str) -> bool {
+    match res_name {
+        "ASP" => atom_name.starts_with("OD"),
+        "GLU" => atom_name.starts_with("OE"),
+        _ => false,
+    }
+}
+
+/// Returns true if the residue is typically hydrophobic.
+fn is_hydrophobic_residue(name: &str) -> bool {
+    matches!(name, "ALA" | "VAL" | "LEU" | "ILE" | "PHE" | "TRP" | "MET" | "PRO")
+}
+
+/// Classify inter-chain interactions from the given contacts.
+///
+/// For each Contact the function finds the closest heavy-atom pair between
+/// the two residues and classifies the interaction by distance and chemistry:
+///   - **H-bond**: N/O donor to N/O/S acceptor, distance <= 3.5 A
+///   - **Salt bridge**: charged N to charged O (or vice-versa), distance <= 4.0 A
+///   - **Hydrophobic contact**: C-C on hydrophobic residues, distance <= 4.5 A
+///   - **Other**: anything not matching the above
+fn classify_interactions(protein: &Protein, contacts: &[Contact]) -> Vec<Interaction> {
+    let mut interactions = Vec::with_capacity(contacts.len());
+
+    for contact in contacts {
+        let res_a = &protein.chains[contact.chain_a].residues[contact.residue_a];
+        let res_b = &protein.chains[contact.chain_b].residues[contact.residue_b];
+
+        // Find the closest heavy-atom pair.
+        let mut best_dist_sq = f64::MAX;
+        let mut best_a: Option<&crate::model::protein::Atom> = None;
+        let mut best_b: Option<&crate::model::protein::Atom> = None;
+
+        for atom_a in &res_a.atoms {
+            if atom_a.element == "H" {
+                continue;
+            }
+            for atom_b in &res_b.atoms {
+                if atom_b.element == "H" {
+                    continue;
+                }
+                let d_sq = dist_sq(atom_a.x, atom_a.y, atom_a.z, atom_b.x, atom_b.y, atom_b.z);
+                if d_sq < best_dist_sq {
+                    best_dist_sq = d_sq;
+                    best_a = Some(atom_a);
+                    best_b = Some(atom_b);
+                }
+            }
+        }
+
+        let (atom_a, atom_b) = match (best_a, best_b) {
+            (Some(a), Some(b)) => (a, b),
+            _ => continue,
+        };
+
+        let distance = best_dist_sq.sqrt();
+
+        // Classify
+        let interaction_type = if distance <= 4.0
+            && ((is_charged_positive(&res_a.name, &atom_a.name)
+                && is_charged_negative(&res_b.name, &atom_b.name))
+                || (is_charged_negative(&res_a.name, &atom_a.name)
+                    && is_charged_positive(&res_b.name, &atom_b.name)))
+        {
+            InteractionType::SaltBridge
+        } else if distance <= 3.5 {
+            let el_a = atom_a.element.as_str();
+            let el_b = atom_b.element.as_str();
+            let donor_acceptor = matches!(el_a, "N" | "O")
+                && matches!(el_b, "N" | "O" | "S");
+            let acceptor_donor = matches!(el_b, "N" | "O")
+                && matches!(el_a, "N" | "O" | "S");
+            if donor_acceptor || acceptor_donor {
+                InteractionType::HydrogenBond
+            } else if el_a == "C"
+                && el_b == "C"
+                && is_hydrophobic_residue(&res_a.name)
+                && is_hydrophobic_residue(&res_b.name)
+            {
+                InteractionType::HydrophobicContact
+            } else {
+                InteractionType::Other
+            }
+        } else if distance <= 4.5
+            && atom_a.element == "C"
+            && atom_b.element == "C"
+            && is_hydrophobic_residue(&res_a.name)
+            && is_hydrophobic_residue(&res_b.name)
+        {
+            InteractionType::HydrophobicContact
+        } else {
+            InteractionType::Other
+        };
+
+        interactions.push(Interaction {
+            interaction_type,
+            atom_a: [atom_a.x, atom_a.y, atom_a.z],
+            atom_b: [atom_b.x, atom_b.y, atom_b.z],
+            distance,
+        });
+    }
+
+    interactions
 }
 
 /// Analyze the interface between all chain pairs in a protein.
@@ -129,12 +267,15 @@ pub fn analyze_interface(protein: &Protein, cutoff: f64) -> InterfaceAnalysis {
 
     let total_interface_residues = interface_residues.len();
 
+    let interactions = classify_interactions(protein, &contacts);
+
     InterfaceAnalysis {
         contacts,
         interface_residues,
         chain_interface_counts,
         total_interface_residues,
         binding_pockets: None,
+        interactions,
     }
 }
 
@@ -179,6 +320,23 @@ pub fn analyze_binding_pockets(protein: &Protein, cutoff: f64) -> BindingPocketA
 }
 
 impl InterfaceAnalysis {
+    /// Return counts of each interaction type: (hbonds, salt_bridges, hydrophobic, other).
+    pub fn interaction_counts(&self) -> (usize, usize, usize, usize) {
+        let mut hbonds = 0;
+        let mut salt_bridges = 0;
+        let mut hydrophobic = 0;
+        let mut other = 0;
+        for interaction in &self.interactions {
+            match interaction.interaction_type {
+                InteractionType::HydrogenBond => hbonds += 1,
+                InteractionType::SaltBridge => salt_bridges += 1,
+                InteractionType::HydrophobicContact => hydrophobic += 1,
+                InteractionType::Other => other += 1,
+            }
+        }
+        (hbonds, salt_bridges, hydrophobic, other)
+    }
+
     /// Convert interface residues to (chain_id, seq_num) pairs using the protein.
     pub fn interface_residues_by_id_with_protein(&self, protein: &Protein) -> HashSet<(String, i32)> {
         let mut set = HashSet::new();

--- a/src/model/interface.rs
+++ b/src/model/interface.rs
@@ -13,7 +13,6 @@ pub enum InteractionType {
 
 /// A classified interaction between two atoms across a chain interface.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Interaction {
     pub interaction_type: InteractionType,
     pub atom_a: [f64; 3],
@@ -241,12 +240,13 @@ pub fn analyze_interface(protein: &Protein, cutoff: f64) -> InterfaceAnalysis {
                     }
 
                     if found_contact {
+                        let min_distance = min_d_sq.sqrt();
                         contacts.push(Contact {
                             chain_a: i,
                             residue_a: ri,
                             chain_b: j,
                             residue_b: rj,
-                            min_distance: min_d_sq.sqrt(),
+                            min_distance,
                         });
                         interface_residues.insert((i, ri));
                         interface_residues.insert((j, rj));

--- a/src/render/braille.rs
+++ b/src/render/braille.rs
@@ -2,6 +2,7 @@ use ratatui::symbols::Marker;
 use ratatui::widgets::canvas::{Canvas, Context, Line};
 
 use crate::app::VizMode;
+use crate::model::interface::{Interaction, InteractionType};
 use crate::model::protein::{LigandType, MoleculeType, Protein};
 use crate::render::camera::Camera;
 use crate::render::color::ColorScheme;
@@ -66,6 +67,7 @@ pub fn render_protein<'a>(
     width: f64,
     height: f64,
     show_ligands: bool,
+    interactions: &'a [Interaction],
 ) -> Canvas<'a, impl Fn(&mut Context<'_>) + 'a> {
     Canvas::default()
         .marker(Marker::Braille)
@@ -83,6 +85,10 @@ pub fn render_protein<'a>(
 
             if show_ligands {
                 render_ligands(ctx, protein, camera, color_scheme);
+            }
+
+            if !interactions.is_empty() {
+                render_interactions(ctx, interactions, camera);
             }
         })
 }
@@ -223,5 +229,38 @@ fn render_ligands(
                 }
             }
         }
+    }
+}
+
+/// Map interaction type to a ratatui color for braille rendering.
+fn braille_interaction_color(t: InteractionType) -> ratatui::style::Color {
+    match t {
+        InteractionType::HydrogenBond => ratatui::style::Color::Rgb(0, 220, 255),       // cyan
+        InteractionType::SaltBridge => ratatui::style::Color::Rgb(255, 80, 80),          // red
+        InteractionType::HydrophobicContact => ratatui::style::Color::Rgb(220, 200, 60), // yellow
+        InteractionType::Other => ratatui::style::Color::Rgb(160, 160, 160),             // gray
+    }
+}
+
+/// Render non-covalent interaction lines in braille mode.
+///
+/// Uses solid lines (not dashed) because braille resolution is too low for
+/// dashes to be visually meaningful.
+fn render_interactions(
+    ctx: &mut Context<'_>,
+    interactions: &[Interaction],
+    camera: &Camera,
+) {
+    for interaction in interactions {
+        let p1 = camera.project(interaction.atom_a[0], interaction.atom_a[1], interaction.atom_a[2]);
+        let p2 = camera.project(interaction.atom_b[0], interaction.atom_b[1], interaction.atom_b[2]);
+        let color = braille_interaction_color(interaction.interaction_type);
+        ctx.draw(&Line {
+            x1: p1.x,
+            y1: p1.y,
+            x2: p2.x,
+            y2: p2.y,
+            color,
+        });
     }
 }

--- a/src/render/framebuffer.rs
+++ b/src/render/framebuffer.rs
@@ -280,6 +280,14 @@ impl Framebuffer {
         dash_len: f64,
         gap_len: f64,
     ) {
+        // Guard: if cycle is zero, non-finite, or either length is negative,
+        // fall back to a solid line to avoid NaN from `accumulated % 0.0`.
+        let cycle = dash_len + gap_len;
+        if cycle <= 0.0 || !cycle.is_finite() || dash_len < 0.0 || gap_len < 0.0 {
+            self.draw_line_3d(p1, p2, color);
+            return;
+        }
+
         let mut x0 = p1[0].round() as isize;
         let mut y0 = p1[1].round() as isize;
         let x1 = p2[0].round() as isize;
@@ -303,7 +311,6 @@ impl Framebuffer {
         // Total Manhattan-ish distance for z interpolation.
         let total_steps = dx.max(-dy) as f64;
 
-        let cycle = dash_len + gap_len;
         let mut accumulated: f64 = 0.0;
         let mut prev_x = x0;
         let mut prev_y = y0;
@@ -1041,5 +1048,31 @@ mod tests {
         fb.draw_dashed_line_3d([-5.0, -5.0, 1.0], [-1.0, -1.0, 1.0], [255, 255, 255], 2.0, 1.0);
         let drawn: usize = fb.color.iter().filter(|c| **c != [0, 0, 0]).count();
         assert_eq!(drawn, 0, "fully off-screen dashed line should draw nothing");
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_zero_cycle_falls_back_to_solid() {
+        let mut fb = Framebuffer::new(20, 1);
+        // dash_len=0, gap_len=0 => cycle=0, which would produce NaN via `% 0.0`.
+        // The guard should fall back to a solid line instead.
+        fb.draw_dashed_line_3d([0.0, 0.0, 1.0], [19.0, 0.0, 2.0], [255, 255, 255], 0.0, 0.0);
+
+        // Every pixel along the horizontal line should be drawn (solid fallback).
+        let drawn: usize = fb.color[..20].iter().filter(|c| **c != [0, 0, 0]).count();
+        assert_eq!(drawn, 20, "zero-cycle dashed line should draw solid (got {} pixels)", drawn);
+
+        // Also verify z-interpolation is intact: endpoints should have expected depths.
+        assert!((fb.depth[0] - 1.0).abs() < 0.5, "start depth should be near 1.0");
+        assert!((fb.depth[19] - 2.0).abs() < 0.5, "end depth should be near 2.0");
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_negative_args_falls_back_to_solid() {
+        let mut fb = Framebuffer::new(10, 1);
+        // Negative dash_len should trigger the guard and draw a solid line.
+        fb.draw_dashed_line_3d([0.0, 0.0, 1.0], [9.0, 0.0, 1.0], [200, 100, 50], -1.0, 3.0);
+
+        let drawn: usize = fb.color[..10].iter().filter(|c| **c != [0, 0, 0]).count();
+        assert_eq!(drawn, 10, "negative dash_len should draw solid (got {} pixels)", drawn);
     }
 }

--- a/src/render/framebuffer.rs
+++ b/src/render/framebuffer.rs
@@ -266,6 +266,95 @@ impl Framebuffer {
         }
     }
 
+    /// Draw a 3D dashed line with z-interpolation.
+    ///
+    /// Like [`draw_line_3d`] but alternates between drawing (`dash_len` pixels)
+    /// and skipping (`gap_len` pixels) based on accumulated pixel distance
+    /// along the line.  Z-interpolation is maintained throughout so that the
+    /// dashed segments interact correctly with the z-buffer.
+    pub fn draw_dashed_line_3d(
+        &mut self,
+        p1: [f64; 3],
+        p2: [f64; 3],
+        color: [u8; 3],
+        dash_len: f64,
+        gap_len: f64,
+    ) {
+        let mut x0 = p1[0].round() as isize;
+        let mut y0 = p1[1].round() as isize;
+        let x1 = p2[0].round() as isize;
+        let y1 = p2[1].round() as isize;
+
+        // Skip lines where both endpoints are entirely off the same side.
+        let w = self.width as isize;
+        let h = self.height as isize;
+        if (x0 < 0 && x1 < 0) || (x0 >= w && x1 >= w)
+            || (y0 < 0 && y1 < 0) || (y0 >= h && y1 >= h)
+        {
+            return;
+        }
+
+        let dx = (x1 - x0).abs();
+        let dy = -(y1 - y0).abs();
+        let sx: isize = if x0 < x1 { 1 } else { -1 };
+        let sy: isize = if y0 < y1 { 1 } else { -1 };
+        let mut err = dx + dy;
+
+        // Total Manhattan-ish distance for z interpolation.
+        let total_steps = dx.max(-dy) as f64;
+
+        let cycle = dash_len + gap_len;
+        let mut accumulated: f64 = 0.0;
+        let mut prev_x = x0;
+        let mut prev_y = y0;
+
+        loop {
+            // Compute interpolation parameter t for z.
+            let t = if total_steps > 0.0 {
+                let from_start_x = (x0 - p1[0].round() as isize).unsigned_abs() as f64;
+                let from_start_y = (y0 - p1[1].round() as isize).unsigned_abs() as f64;
+                from_start_x.max(from_start_y) / total_steps
+            } else {
+                0.0
+            };
+            let z = p1[2] * (1.0 - t) + p2[2] * t;
+
+            // Accumulate Euclidean distance from previous pixel.
+            let step_dx = (x0 - prev_x) as f64;
+            let step_dy = (y0 - prev_y) as f64;
+            accumulated += (step_dx * step_dx + step_dy * step_dy).sqrt();
+            prev_x = x0;
+            prev_y = y0;
+
+            // Determine if we are in a dash or gap segment.
+            let phase = accumulated % cycle;
+            let drawing = phase < dash_len;
+
+            if drawing
+                && x0 >= 0
+                && y0 >= 0
+                && (x0 as usize) < self.width
+                && (y0 as usize) < self.height
+            {
+                self.set_pixel(x0 as usize, y0 as usize, z, color);
+            }
+
+            if x0 == x1 && y0 == y1 {
+                break;
+            }
+
+            let e2 = 2 * err;
+            if e2 >= dy {
+                err += dy;
+                x0 += sx;
+            }
+            if e2 <= dx {
+                err += dx;
+                y0 += sy;
+            }
+        }
+    }
+
     /// Draw a 3D line with the given pixel thickness.
     ///
     /// For each pixel along the main Bresenham line, a filled circle of the
@@ -890,5 +979,67 @@ mod tests {
         // Background pixels must remain [0,0,0]
         assert_eq!(fb.color[2], [0, 0, 0], "background pixel at index 2 should stay black");
         assert_eq!(fb.color[3], [0, 0, 0], "background pixel at index 3 should stay black");
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_has_gaps() {
+        let mut fb = Framebuffer::new(20, 1);
+        // Horizontal dashed line across the entire width: dash=3, gap=3
+        fb.draw_dashed_line_3d([0.0, 0.0, 1.0], [19.0, 0.0, 2.0], [255, 255, 255], 3.0, 3.0);
+
+        // Count drawn (non-black) and gap (black) pixels.
+        let drawn: usize = fb.color[..20].iter().filter(|c| **c != [0, 0, 0]).count();
+        let gap: usize = fb.color[..20].iter().filter(|c| **c == [0, 0, 0]).count();
+
+        // There should be both drawn and gap pixels (not all drawn, not all gap).
+        assert!(drawn > 0, "dashed line should draw some pixels");
+        assert!(gap > 0, "dashed line should leave some gaps");
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_z_interpolation() {
+        let mut fb = Framebuffer::new(10, 1);
+        fb.draw_dashed_line_3d([0.0, 0.0, 1.0], [9.0, 0.0, 10.0], [255, 255, 255], 100.0, 0.0);
+
+        // With dash_len >> line length, all pixels should be drawn.
+        // Check z interpolation: first pixel should be near 1.0, last near 10.0.
+        assert!((fb.depth[0] - 1.0).abs() < 0.5, "start depth should be near 1.0, got {}", fb.depth[0]);
+        assert!((fb.depth[9] - 10.0).abs() < 0.5, "end depth should be near 10.0, got {}", fb.depth[9]);
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_respects_zbuffer() {
+        let mut fb = Framebuffer::new(10, 1);
+        // Draw a solid foreground line at z=1
+        fb.draw_line_3d([0.0, 0.0, 1.0], [9.0, 0.0, 1.0], [255, 0, 0]);
+        // Draw a dashed background line at z=5 (farther) — should not overwrite
+        fb.draw_dashed_line_3d([0.0, 0.0, 5.0], [9.0, 0.0, 5.0], [0, 255, 0], 100.0, 0.0);
+
+        // All pixels should remain red (closer z wins)
+        for i in 0..10 {
+            assert_eq!(fb.color[i], [255, 0, 0], "pixel {} should stay red (z-buffer)", i);
+        }
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_diagonal() {
+        let mut fb = Framebuffer::new(10, 10);
+        fb.draw_dashed_line_3d([0.0, 0.0, 1.0], [9.0, 9.0, 2.0], [128, 128, 128], 2.0, 2.0);
+
+        // At least the first pixel should be drawn (start of first dash).
+        assert_ne!(fb.color[0], [0, 0, 0], "first pixel of diagonal dashed line should be drawn");
+
+        // Count total drawn pixels — should be roughly half of the diagonal length.
+        let total_drawn: usize = fb.color.iter().filter(|c| **c != [0, 0, 0]).count();
+        assert!(total_drawn > 0 && total_drawn < 14, "diagonal should have partial coverage, got {}", total_drawn);
+    }
+
+    #[test]
+    fn test_draw_dashed_line_3d_offscreen_clipped() {
+        let mut fb = Framebuffer::new(10, 10);
+        // Both endpoints off the same side — should be silently skipped.
+        fb.draw_dashed_line_3d([-5.0, -5.0, 1.0], [-1.0, -1.0, 1.0], [255, 255, 255], 2.0, 1.0);
+        let drawn: usize = fb.color.iter().filter(|c| **c != [0, 0, 0]).count();
+        assert_eq!(drawn, 0, "fully off-screen dashed line should draw nothing");
     }
 }

--- a/src/render/hd.rs
+++ b/src/render/hd.rs
@@ -1,4 +1,5 @@
 use crate::app::VizMode;
+use crate::model::interface::{Interaction, InteractionType};
 use crate::model::protein::{LigandType, MoleculeType, Protein};
 use crate::render::camera::Camera;
 use crate::render::color::{color_to_rgb, ColorScheme};
@@ -20,6 +21,7 @@ pub fn render_hd_framebuffer(
     height: f64,
     mesh: &[RibbonTriangle],
     show_ligands: bool,
+    interactions: &[Interaction],
 ) -> Framebuffer {
     let px_w = width as usize;
     let px_h = height as usize;
@@ -70,6 +72,11 @@ pub fn render_hd_framebuffer(
     // Render small molecules as ball-and-stick overlay
     if show_ligands {
         render_ligands_fb(&mut fb, protein, camera, color_scheme, half_w, half_h, ts);
+    }
+
+    // Render interaction lines (dashed) between interface atom pairs.
+    if !interactions.is_empty() {
+        render_interactions_fb(&mut fb, interactions, camera, half_w, half_h);
     }
 
     // Post-pass: blend all rasterized pixels toward a cool blue-gray fog color
@@ -282,5 +289,33 @@ fn render_ligands_fb(
                 }
             }
         }
+    }
+}
+
+/// Render non-covalent interaction lines as dashed segments in the framebuffer.
+fn render_interactions_fb(
+    fb: &mut Framebuffer,
+    interactions: &[Interaction],
+    camera: &Camera,
+    half_w: f64,
+    half_h: f64,
+) {
+    for interaction in interactions {
+        let p1 = camera.project(interaction.atom_a[0], interaction.atom_a[1], interaction.atom_a[2]);
+        let p2 = camera.project(interaction.atom_b[0], interaction.atom_b[1], interaction.atom_b[2]);
+        let px1 = to_pixel(p1.x, p1.y, p1.z, half_w, half_h);
+        let px2 = to_pixel(p2.x, p2.y, p2.z, half_w, half_h);
+        let color = interaction_color(interaction.interaction_type);
+        fb.draw_dashed_line_3d(px1, px2, color, 4.0, 3.0);
+    }
+}
+
+/// Map interaction type to an RGB color for rendering.
+fn interaction_color(t: InteractionType) -> [u8; 3] {
+    match t {
+        InteractionType::HydrogenBond => [0, 220, 255],       // cyan
+        InteractionType::SaltBridge => [255, 80, 80],          // red
+        InteractionType::HydrophobicContact => [220, 200, 60], // yellow
+        InteractionType::Other => [160, 160, 160],             // gray
     }
 }

--- a/src/render/hd.rs
+++ b/src/render/hd.rs
@@ -74,15 +74,15 @@ pub fn render_hd_framebuffer(
         render_ligands_fb(&mut fb, protein, camera, color_scheme, half_w, half_h, ts);
     }
 
-    // Render interaction lines (dashed) between interface atom pairs.
-    if !interactions.is_empty() {
-        render_interactions_fb(&mut fb, interactions, camera, half_w, half_h);
-    }
-
     // Post-pass: blend all rasterized pixels toward a cool blue-gray fog color
     // based on their z-buffer depth.  This gives uniform depth cues across all
     // rendering modes (triangles, lines, circles).
     fb.apply_depth_tint([40, 50, 70], 0.35);
+
+    // Render interaction lines AFTER depth tint so their color coding stays vivid.
+    if !interactions.is_empty() {
+        render_interactions_fb(&mut fb, interactions, camera, half_w, half_h);
+    }
 
     fb
 }

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -6,12 +6,12 @@ use ratatui::Frame;
 
 /// Render a centered help overlay
 pub fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    // Center the popup (60x20) — guard against tiny terminals
+    // Center the popup — guard against tiny terminals
     if area.width < 10 || area.height < 10 {
         return;
     }
     let popup_width = 60u16.min(area.width.saturating_sub(4));
-    let popup_height = 21u16.min(area.height.saturating_sub(4));
+    let popup_height = 23u16.min(area.height.saturating_sub(4));
     let x = (area.width - popup_width) / 2;
     let y = (area.height - popup_height) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
@@ -32,6 +32,8 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(vec![Span::styled("  m          ", Style::default().fg(Color::Yellow)), Span::raw("Toggle Braille / HD")]),
         Line::from(vec![Span::styled("  M          ", Style::default().fg(Color::Yellow)), Span::raw("Toggle HD / FullHD (Sixel/Kitty)")]),
         Line::from(vec![Span::styled("  [ / ]      ", Style::default().fg(Color::Yellow)), Span::raw("Prev / next chain")]),
+        Line::from(vec![Span::styled("  f          ", Style::default().fg(Color::Yellow)), Span::raw("Toggle interface analysis")]),
+        Line::from(vec![Span::styled("  I          ", Style::default().fg(Color::Yellow)), Span::raw("Toggle interface interactions")]),
         Line::from(vec![Span::styled("  g          ", Style::default().fg(Color::Yellow)), Span::raw("Toggle ligand visibility")]),
         Line::from(vec![Span::styled("  Space      ", Style::default().fg(Color::Yellow)), Span::raw("Toggle auto-rotation")]),
         Line::from(vec![Span::styled("  ?          ", Style::default().fg(Color::Yellow)), Span::raw("Toggle this help")]),

--- a/src/ui/helpbar.rs
+++ b/src/ui/helpbar.rs
@@ -22,6 +22,8 @@ pub fn render_helpbar(frame: &mut Frame, area: Rect) {
         Span::styled(": mode  ", Style::default().fg(Color::Gray)),
         Span::styled("f", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
         Span::styled(": interface  ", Style::default().fg(Color::Gray)),
+        Span::styled("I", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        Span::styled(": interactions  ", Style::default().fg(Color::Gray)),
         Span::styled("?", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
         Span::styled(": help  ", Style::default().fg(Color::Gray)),
         Span::styled("g", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),

--- a/src/ui/interface_panel.rs
+++ b/src/ui/interface_panel.rs
@@ -120,22 +120,22 @@ pub fn render_interface_panel(
         )));
         lines.push(Line::from(vec![
             Span::styled(" ", Style::default()),
-            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(0, 180, 255))),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(0, 220, 255))),
             Span::styled(format!(" H-bond: {}", hbonds), Style::default().fg(Color::White)),
         ]));
         lines.push(Line::from(vec![
             Span::styled(" ", Style::default()),
-            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(255, 60, 60))),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(255, 80, 80))),
             Span::styled(format!(" Salt bridge: {}", salt_bridges), Style::default().fg(Color::White)),
         ]));
         lines.push(Line::from(vec![
             Span::styled(" ", Style::default()),
-            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(255, 220, 50))),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(220, 200, 60))),
             Span::styled(format!(" Hydrophobic: {}", hydrophobic), Style::default().fg(Color::White)),
         ]));
         lines.push(Line::from(vec![
             Span::styled(" ", Style::default()),
-            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(180, 180, 180))),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(160, 160, 160))),
             Span::styled(format!(" Other: {}", other), Style::default().fg(Color::White)),
         ]));
     } else {

--- a/src/ui/interface_panel.rs
+++ b/src/ui/interface_panel.rs
@@ -14,6 +14,8 @@ pub fn render_interface_panel(
     summary_lines: &[String],
     focus_chain: usize,
     chain_names: &[String],
+    show_interactions: bool,
+    interaction_counts: (usize, usize, usize, usize),
 ) {
     let mut lines: Vec<Line> = Vec::new();
 
@@ -106,6 +108,41 @@ pub fn render_interface_panel(
             Span::styled("\u{2588}", Style::default().fg(Color::Rgb(0, 255, 255))),
             Span::styled(" Ion", Style::default().fg(Color::DarkGray)),
         ]));
+    }
+
+    // Interaction section
+    lines.push(Line::from(""));
+    if show_interactions {
+        let (hbonds, salt_bridges, hydrophobic, other) = interaction_counts;
+        lines.push(Line::from(Span::styled(
+            " Interactions",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(0, 180, 255))),
+            Span::styled(format!(" H-bond: {}", hbonds), Style::default().fg(Color::White)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(255, 60, 60))),
+            Span::styled(format!(" Salt bridge: {}", salt_bridges), Style::default().fg(Color::White)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(255, 220, 50))),
+            Span::styled(format!(" Hydrophobic: {}", hydrophobic), Style::default().fg(Color::White)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(" ", Style::default()),
+            Span::styled("\u{2588}", Style::default().fg(Color::Rgb(180, 180, 180))),
+            Span::styled(format!(" Other: {}", other), Style::default().fg(Color::White)),
+        ]));
+    } else {
+        lines.push(Line::from(Span::styled(
+            " [Shift+I]: show interactions",
+            Style::default().fg(Color::DarkGray),
+        )));
     }
 
     let panel = Paragraph::new(lines)

--- a/src/ui/statusbar.rs
+++ b/src/ui/statusbar.rs
@@ -80,6 +80,13 @@ pub fn render_statusbar(frame: &mut Frame, area: Rect, app: &App) {
             spans.push(Span::raw(" "));
         }
 
+        // Show interactions indicator
+        if app.show_interface && app.show_interactions {
+            spans.push(Span::styled("\u{2502} ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("Interactions", Style::default().fg(Color::Cyan)));
+            spans.push(Span::raw(" "));
+        }
+
         let info = Paragraph::new(Line::from(spans));
         frame.render_widget(info, info_area);
     }

--- a/src/ui/viewport.rs
+++ b/src/ui/viewport.rs
@@ -5,6 +5,7 @@ use ratatui_image::picker::ProtocolType;
 use ratatui_image::{Image, Resize};
 
 use crate::app::{App, RenderMode};
+use crate::model::interface::Interaction;
 use crate::render::braille;
 use crate::render::framebuffer::framebuffer_to_braille_widget;
 use crate::render::hd;
@@ -12,6 +13,12 @@ use crate::render::kitty_png::KittyPngImage;
 
 /// Render the main 3D viewport
 pub fn render_viewport(frame: &mut Frame, area: Rect, app: &App) {
+    let interactions: &[Interaction] = if app.show_interface && app.show_interactions {
+        &app.interface_analysis.interactions
+    } else {
+        &[]
+    };
+
     match app.render_mode {
         RenderMode::Braille => {
             // Braille mode: 2x4 dots per cell, higher resolution but monochrome per cell
@@ -26,6 +33,7 @@ pub fn render_viewport(frame: &mut Frame, area: Rect, app: &App) {
                 width,
                 height,
                 app.show_ligands,
+                interactions,
             );
 
             frame.render_widget(canvas, area);
@@ -47,20 +55,21 @@ pub fn render_viewport(frame: &mut Frame, area: Rect, app: &App) {
                 height,
                 &app.mesh_cache,
                 app.show_ligands,
+                interactions,
             );
 
             let widget = framebuffer_to_braille_widget(&fb);
             frame.render_widget(widget, area);
         }
         RenderMode::FullHD => {
-            render_fullhd_viewport(frame, area, app);
+            render_fullhd_viewport(frame, area, app, interactions);
         }
     }
 }
 
 /// Render the FullHD viewport using graphics protocol (Sixel/Kitty/iTerm2) when
 /// available, falling back to colored braille characters otherwise.
-fn render_fullhd_viewport(frame: &mut Frame, area: Rect, app: &App) {
+fn render_fullhd_viewport(frame: &mut Frame, area: Rect, app: &App, interactions: &[Interaction]) {
     let proto = app.picker.protocol_type();
     let (font_w, font_h) = app.picker.font_size();
 
@@ -90,6 +99,7 @@ fn render_fullhd_viewport(frame: &mut Frame, area: Rect, app: &App) {
         px_h,
         &app.mesh_cache,
         app.show_ligands,
+        interactions,
     );
 
     // If the terminal supports a real graphics protocol, convert the


### PR DESCRIPTION
## Summary
- **Interaction classification**: Categorizes interface contacts as H-bonds (≤3.5Å N/O donors), salt bridges (≤4.0Å charged residues), hydrophobic contacts (≤4.5Å C-C), or other
- **3D visualization**: Dashed lines between interacting atom pairs in HD/FullHD modes, solid lines in Braille, color-coded by type (cyan/red/yellow/gray)
- **Toggle**: `Shift+I` when interface mode (`f`) is active. Off by default.
- **UI indicators**: Sidebar shows interaction counts with color legend, status bar shows "Interactions" when active

## Changes (3 commits)
- `0abcf32` feat: add interface interaction classification and UI controls
- `5284c8e` feat: add dashed interaction lines for interface visualization
- `8fd6f95` feat: add interface interactions to help overlay and helpbar

## Test plan
- [ ] Load a multi-chain protein (e.g., `--fetch 1ZVH` or `examples/1AOI.pdb`)
- [ ] Press `f` to enable interface mode — sidebar shows interface summary
- [ ] Press `I` (Shift+I) — dashed interaction lines appear in viewport
- [ ] Rotate protein — interaction lines move correctly with z-buffering
- [ ] Status bar shows "Interactions" indicator
- [ ] Sidebar shows interaction type counts and color legend
- [ ] Press `I` again — interactions toggle off, lines disappear
- [ ] Press `f` — interface mode off, interactions also dismissed
- [ ] Verify all 3 render modes (Braille/HD/FullHD) show interactions
- [ ] `I` does nothing when interface mode is not active

🤖 Generated with [Claude Code](https://claude.com/claude-code)